### PR TITLE
Feature/auto test

### DIFF
--- a/template/cpp/.gitignore
+++ b/template/cpp/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_for_test/
 bin/
 .cache/
 wt-*

--- a/template/cpp/CMakeLists.txt
+++ b/template/cpp/CMakeLists.txt
@@ -2,14 +2,40 @@
 cmake_minimum_required( VERSION 3.22.1 )
 
 # プロジェクト名と使用する言語を指定
-project( name_of_this_project LANGUAGES CXX )
-set( CMAKE_CXX_STANDARD 20 )
+project( crep LANGUAGES CXX )
 
 # compile_commands.jsonを出力するように設定
 set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
 
-# コンパイラを指定
-set( CMAKE_CXX_COMPILER clang++ )
+set( is_valid_compiler false )
+set( supported_compilers "clang++;g++" )
+foreach( supported_compiler IN LISTS supported_compilers )
+  if( "${supported_compiler}" STREQUAL "${compiler}" )
+    set( is_valid_compiler true )
+    break()
+  endif()
+endforeach()
+if( NOT is_valid_compiler )
+  message( FATAL_ERROR "${compiler} is not supported" )
+endif()
+
+set( is_valid_version false )
+set( supported_versions 17;20 )
+foreach( supported_version IN LISTS supported_versions )
+  if( supported_version EQUAL ${std_version} )
+    set( is_valid_version true )
+    break()
+  endif()
+endforeach()
+if( NOT is_valid_version )
+  message( FATAL_ERROR "C++${std_version} is not supported." )
+endif()
+
+set( CMAKE_CXX_COMPILER ${compiler} )
+message( STATUS "used compiler: ${compiler}" )
+
+set( CMAKE_CXX_STANDARD ${std_version} )
+message( STATUS "std version: ${std_version}" )
 
 # CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDESがONになっていないと
 # unixスタイルのインクルードパス指定になるため、
@@ -20,16 +46,6 @@ set( CMAKE_CXX_COMPILER clang++ )
 # その別ファイルにはWindowsスタイルでパスが書き込まれるため、
 # その問題をクリアできる。
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES ON)
-
-# 利用できるプロセッサ数を調べる
-include(ProcessorCount)
-ProcessorCount(PROCESSOR_NUM)
-
-# ProcessorCountが失敗していないことを確かめる
-if(NOT PROCESSOR_NUM EQUAL 0)
-  set(CTEST_BUILD_FLAGS -j${PROCESSOR_NUM})
-  set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${PROCESSOR_NUM})
-endif()
 
 # サブディレクトリを追加
 add_subdirectory( src )

--- a/template/cpp/build.cmake
+++ b/template/cpp/build.cmake
@@ -1,27 +1,35 @@
 cmake_minimum_required( VERSION 3.22.1 )
 
-set( build_dir ${CMAKE_CURRENT_LIST_DIR}/build )
+include( cmake/ndef_value.cmake )
+include( cmake/config.cmake )
+include( cmake/build_directory.cmake )
+
+display_value( build_type )
+display_value( compiler )
+display_value( std_version )
+display_value( slib )
+
+build_directory( "${test}" ${compiler} ${std_version} build_dir )
+
+display_value( build_dir )
 
 if( NOT EXISTS ${build_dir} )
   file( MAKE_DIRECTORY ${build_dir} )
 endif()
 
-if( NOT DEFINED build_type )
-  set( build_type Debug )
-endif()
-
-message( STATUS "build_type: ${build_type}" )
-
-if( NOT DEFINED slib )
-  set( slib libstdc++ )
-endif()
-
 execute_process(
-  COMMAND ${CMAKE_COMMAND} .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Dslib=${slib}
+  COMMAND ${CMAKE_COMMAND} ${project_root} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Dslib=${slib} -Dstd_version=${std_version} -Dcompiler=${compiler}
+  RESULT_VARIABLE is_error_occured
   WORKING_DIRECTORY ${build_dir}
 )
 
-execute_process(
-  COMMAND ${CMAKE_COMMAND} --build . -j8
-  WORKING_DIRECTORY ${build_dir}
-)
+include( cmake/processor_num.cmake )
+count_processor( processor_num )
+message( STATUS "processor num: ${processor_num}" )
+
+if( ${is_error_occured} EQUAL 0 )
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --build . -j${processor_num}
+    WORKING_DIRECTORY ${build_dir}
+  )
+endif()

--- a/template/cpp/cmake/build_directory.cmake
+++ b/template/cpp/cmake/build_directory.cmake
@@ -1,0 +1,11 @@
+include( cmake/ndef_value.cmake )
+
+function( build_directory test specified_compiler specified_version result )
+  if( ${test} )
+    set( ${result} ${CMAKE_SOURCE_DIR}/build_for_test/${specified_compiler}/${specified_version} PARENT_SCOPE )
+  else()
+    set( ${result} ${CMAKE_SOURCE_DIR}/build PARENT_SCOPE )
+  endif()
+endfunction()
+
+set( project_root ${CMAKE_SOURCE_DIR} )

--- a/template/cpp/cmake/compile_option.cmake
+++ b/template/cpp/cmake/compile_option.cmake
@@ -1,6 +1,7 @@
 # MSVCとgcc系のコンパイラでは、オプションの指定方法が違うので、
 # それに対応するためにジェネレータ式を利用している。
 set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
+set( clang_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang>" )
 set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
 set( warning_options_for_clang_like -Wall -Wextra -Wshadow -Wformat=2 -Wunused )
 set( warning_options_for_msvc -W3 )
@@ -15,7 +16,7 @@ if(MINGW)
   # -target x86_64-w64-windows-gnuというオプションが
   # windows上のすべての環境に必要なのかどうかが分からないので、
   # とりあえずMSYS2環境では有効となるようにしている。
-  set( target_if_msys2 -target x86_64-w64-windows-gnu )
+  set( target_if_msys2 $<${clang_cxx}:-target x86_64-w64-windows-gnu> )
 endif()
 
 function( add_compile_option TARGET_NAME )

--- a/template/cpp/cmake/config.cmake
+++ b/template/cpp/cmake/config.cmake
@@ -1,0 +1,17 @@
+##################################################
+# Copyright(c) 2023 Akito Dataminer
+#
+# This software is released under the MIT License.
+# Refer the accompanying LICENSE.txt or the description
+# at the provided URL for details.
+# http://opensource.org/licenses/mit-license.php
+##################################################
+# This script defines the default values for arguments
+# passed to cmake during the configuration phase.
+##################################################
+include( cmake/ndef_value.cmake )
+
+ifndef_default( build_type Debug )
+ifndef_default( compiler clang++ )
+ifndef_default( std_version 20 )
+ifndef_default( slib libstdc++ )

--- a/template/cpp/cmake/ndef_value.cmake
+++ b/template/cpp/cmake/ndef_value.cmake
@@ -1,0 +1,18 @@
+##################################################
+# Copyright(c) 2023 Akito Dataminer
+#
+# This software is released under the MIT License.
+# Refer the accompanying LICENSE.txt or the description
+# at the provided URL for details.
+# http://opensource.org/licenses/mit-license.php
+##################################################
+macro( ifndef_default variable_name default_value )
+  if( NOT DEFINED ${variable_name} )
+    set( ${variable_name} ${default_value} )
+  endif()
+endmacro()
+
+macro( display_value variable_name )
+  message( STATUS "${variable_name}: ${${variable_name}}" )
+endmacro()
+

--- a/template/cpp/cmake/processor_num.cmake
+++ b/template/cpp/cmake/processor_num.cmake
@@ -1,0 +1,20 @@
+##################################################
+# Copyright(c) 2023 Akito Dataminer
+#
+# This software is released under the MIT License.
+# Refer the accompanying LICENSE.txt or the description
+# at the provided URL for details.
+# http://opensource.org/licenses/mit-license.php
+##################################################
+
+include(ProcessorCount)
+function( count_processor result )
+  ProcessorCount( COUNTED_NUM )
+
+  # Ensure that ProcessorCount has not failed.
+  if( NOT COUNTED_NUM EQUAL 0 )
+    set( ${result} ${COUNTED_NUM} PARENT_SCOPE )
+  else()
+    set( ${result} 1 PARENT_SCOPE )
+  endif()
+endfunction()

--- a/template/cpp/src/CMakeLists.txt
+++ b/template/cpp/src/CMakeLists.txt
@@ -15,6 +15,14 @@ target_include_directories( ${OUTPUT} PUBLIC ${INCLUDE_DIRECTORY} )
 include( ${PROJECT_SOURCE_DIR}/cmake/compile_option.cmake )
 add_compile_option( ${OUTPUT} )
 
+if( WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+  set( CMAKE_INSTALL_PREFIX "C:/Program Files/crep" CACHE PATH "Installation path prefix absorbed the difference of UNIX(Linux) and Windows" FORCE )
+endif()
+
+include( ${PROJECT_SOURCE_DIR}/cmake/ndef_value.cmake )
+display_value( CMAKE_INSTALL_PREFIX )
+install( TARGETS ${OUTPUT} RUNTIME )
+
 ##############################
 # バージョン情報を定義したヘッダファイルを生成する
 ##############################
@@ -27,7 +35,3 @@ add_custom_command(OUTPUT ${VERSION_INFORMATION_HEADER}
   COMMAND ${CMAKE_COMMAND} -P ${VERSION_SCRIPT_PATH}
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
 )
-
-# リンクするライブラリの指定
-# find_library(WS2_32_LIBRARY ws2_32)
-# target_link_libraries(out PUBLIC ${WS2_32_LIBRARY})

--- a/template/cpp/test.cmake
+++ b/template/cpp/test.cmake
@@ -1,0 +1,50 @@
+##################################################
+# Copyright(c) 2023 Akito Dataminer
+#
+# This software is released under the MIT License.
+# Refer the accompanying LICENSE.txt or the description
+# at the provided URL for details.
+# http://opensource.org/licenses/mit-license.php
+##################################################
+# このスクリプトは、コンパイラと標準規格の組み合わせを変えて
+# build.cmakeを実行し、テストケースと本体をコンパイルする。
+# その後、そのテストケースを実行する。
+##################################################
+# This script runs build.cmake with different combinations of compilers and
+# standards to compile the main source code and test cases.
+# After that, this script executes the test cases.
+##################################################
+set( available_compilers clang++;g++ )
+set( available_std_versions 17;20 )
+set( test 1 )
+
+include( cmake/ndef_value.cmake )
+include( cmake/config.cmake )
+include( cmake/build_directory.cmake )
+
+# compile
+set( test_directories )
+foreach( compiler IN LISTS available_compilers )
+  foreach( std_version IN LISTS available_std_versions )
+    build_directory( ${test} ${compiler} ${std_version} build_directory )
+    list( APPEND test_directories ${build_directory} )
+
+    message( STATUS "Now compiling by ${compiler} with C++${std_version}" )
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} . -Dtest=1 -Dstd_version=${std_version} -Dcompiler=${compiler} -P build.cmake
+      WORKING_DIRECTORY ${project_root}
+    )
+    message( "" )
+  endforeach()
+endforeach()
+
+# test
+include( cmake/processor_num.cmake )
+count_processor( processor_num )
+
+foreach( test_directory IN LISTS test_directories )
+  execute_process(
+    COMMAND ${CMAKE_CTEST_COMMAND} -j${processor_num}
+    WORKING_DIRECTORY ${test_directory}
+  )
+endforeach()

--- a/template/cpp/test/CMakeLists.txt
+++ b/template/cpp/test/CMakeLists.txt
@@ -1,8 +1,13 @@
 set( TEST_DIRECTORY ${PROJECT_SOURCE_DIR}/test )
 include( ${TEST_DIRECTORY}/AddTestHelpers.cmake )
 
-# set( SUB_DIR sub )
+set( SUB_DIR_UTIL util )
+set( SUB_DIR_PATH path )
+set( SUB_DIR_ITERATOR iterator )
 
 ## テストケースの追加
-# create_test_case( sourceTest1.cpp )
-# create_test_case( ${SUB_DIR}/sourceTest2.cpp )
+create_test_case( ${SUB_DIR_UTIL}/throw_if.cpp )
+create_test_case( ${SUB_DIR_PATH}/branch.cpp )
+create_test_case( ${SUB_DIR_PATH}/parse.cpp )
+create_test_case( ${SUB_DIR_PATH}/character.cpp )
+create_test_case( ${SUB_DIR_ITERATOR}/index_t.cpp )


### PR DESCRIPTION
# English
## Purpose
I made it easier to run tests.

## Main Modifications
Modifications to the cmake script:
1. Using "cmake -Dbuild_type=Debug -Dslib=libc++ -Dcompiler=g++ -Dstd_version=20 build.cmake", developers can switch compiling conditions, compilers, and other settings.
2. Test executables are output to build_for_cmake.
3. Using "cmake -P test.cmake" now automatically generates and runs the test executable.

# 日本語（ Original ）
## 目的
テストを簡単に実行できるようにした。

## 主な変更
cmake scriptの変更
1. cmake -Dbuild_type=Debug -Dslib=libc++ -Dcompiler=g++ -Dstd_version=20 build.cmakeで、コンパイラ等を切り替えられるようにした。
2. test用の実行ファイルをbuild_for_cmakeに出力するようにした。
3. cmake -P test.cmakeでtest用実行ファイルの生成と、実行を自動でできるようにした。

